### PR TITLE
allow to remove the reigstered type from the history.

### DIFF
--- a/src/MoonSharp.Interpreter/DataTypes/UserData.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/UserData.cs
@@ -199,9 +199,10 @@ namespace MoonSharp.Interpreter
 		/// Additionally, it's a good practice to discard all previous loaded scripts after calling this method.
 		/// </summary>
 		/// <typeparam name="T">The type to be unregistered</typeparam>
-		public static void UnregisterType<T>()
+		/// <param name="deleteHistory">Type removed from registration history</param>
+		public static void UnregisterType<T>(bool deleteHistory = false)
 		{
-			TypeDescriptorRegistry.UnregisterType(typeof(T));
+			TypeDescriptorRegistry.UnregisterType(typeof(T), deleteHistory);
 		}
 
 		/// <summary>
@@ -211,9 +212,10 @@ namespace MoonSharp.Interpreter
 		/// Additionally, it's a good practice to discard all previous loaded scripts after calling this method.
 		/// </summary>
 		/// <param name="t">The The type to be unregistered</param>
-		public static void UnregisterType(Type t)
+		/// <param name="deleteHistory">Type removed from registration history</param>
+		public static void UnregisterType(Type t, bool deleteHistory = false)
 		{
-			TypeDescriptorRegistry.UnregisterType(t);
+			TypeDescriptorRegistry.UnregisterType(t, deleteHistory);
 		}
 
 		/// <summary>

--- a/src/MoonSharp.Interpreter/Interop/UserDataRegistries/TypeDescriptorRegistry.cs
+++ b/src/MoonSharp.Interpreter/Interop/UserDataRegistries/TypeDescriptorRegistry.cs
@@ -86,13 +86,14 @@ namespace MoonSharp.Interpreter.Interop.UserDataRegistries
 		/// Additionally, it's a good practice to discard all previous loaded scripts after calling this method.
 		/// </summary>
 		/// <param name="t">The The type to be unregistered</param>
-		internal static void UnregisterType(Type t)
+		/// <param name="deleteHistory">Type removed from registration history</param>
+		internal static void UnregisterType(Type t, bool deleteHistory = false)
 		{
 			lock (s_Lock)
 			{
 				if (s_TypeRegistry.ContainsKey(t))
 				{
-					PerformRegistration(t, null, s_TypeRegistry[t]);
+					PerformRegistration(t, null, s_TypeRegistry[t], deleteHistory);
 				}
 			}
 		}
@@ -191,7 +192,7 @@ namespace MoonSharp.Interpreter.Interop.UserDataRegistries
 			}
 		}
 
-		private static IUserDataDescriptor PerformRegistration(Type type, IUserDataDescriptor newDescriptor, IUserDataDescriptor oldDescriptor)
+		private static IUserDataDescriptor PerformRegistration(Type type, IUserDataDescriptor newDescriptor, IUserDataDescriptor oldDescriptor, bool deleteHistory = false)
 		{
 			IUserDataDescriptor result = RegistrationPolicy.HandleRegistration(newDescriptor, oldDescriptor);
 
@@ -200,6 +201,7 @@ namespace MoonSharp.Interpreter.Interop.UserDataRegistries
 				if (result == null)
 				{
 					s_TypeRegistry.Remove(type);
+					if (deleteHistory) { s_TypeRegistryHistory.Remove(type); }
 				}
 				else
 				{


### PR DESCRIPTION
**Issue**
The registered type will be strongly-referenced by the registered history, and causes the dynamic assembly related the type not able to be unloaded.
so i added a parameter for method `UnregisterType` that represented to remove the type from the history.

**Why i wanna do that?**
LuaForBarotruamaUnstable encounted it, every reloadlua, a new assembly will be created for c# script, but if lua script register a type of ACsMod, the newed assembly can't be collected by GC, and there are many types with the same full-name appeared, this let lua script has no idea which type should be registered.

**Test Result**
Dynamic assemblies can be unloaded immediately using GC, Never encountered again.