### PR TITLE
Remove deprecated MSBuild properties

### DIFF
--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/MoonSharp.Interpreter.netcore.csproj
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/MoonSharp.Interpreter.netcore.csproj
@@ -9,7 +9,6 @@
     <DefineConstants>$(DefineConstants);DOTNET_CORE;NETFX_CORE</DefineConstants>
     <AssemblyName>MoonSharp.Interpreter</AssemblyName>
     <PackageId>MoonSharp.Interpreter.netcore</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/MoonSharp.Interpreter.netcore.csproj
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/MoonSharp.Interpreter.netcore.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>MoonSharp.Interpreter</AssemblyName>
     <PackageId>MoonSharp.Interpreter.netcore</PackageId>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/MoonSharp.VsCodeDebugger/_Projects/MoonSharp.VsCodeDebugger.netcore/MoonSharp.VsCodeDebugger.netcore.csproj
+++ b/src/MoonSharp.VsCodeDebugger/_Projects/MoonSharp.VsCodeDebugger.netcore/MoonSharp.VsCodeDebugger.netcore.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>MoonSharp.VsCodeDebugger</AssemblyName>
     <PackageId>MoonSharp.VsCodeDebugger.netcore</PackageId>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/MoonSharp.VsCodeDebugger/_Projects/MoonSharp.VsCodeDebugger.netcore/MoonSharp.VsCodeDebugger.netcore.csproj
+++ b/src/MoonSharp.VsCodeDebugger/_Projects/MoonSharp.VsCodeDebugger.netcore/MoonSharp.VsCodeDebugger.netcore.csproj
@@ -9,7 +9,6 @@
     <DefineConstants>$(DefineConstants);DOTNET_CORE;NETFX_CORE</DefineConstants>
     <AssemblyName>MoonSharp.VsCodeDebugger</AssemblyName>
     <PackageId>MoonSharp.VsCodeDebugger.netcore</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/TestRunners/DotNetCoreTestRunner/DotNetCoreTestRunner.csproj
+++ b/src/TestRunners/DotNetCoreTestRunner/DotNetCoreTestRunner.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>DotNetCoreTestRunner</PackageId>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 


### PR DESCRIPTION
The `PackageTargetFallback` property prevents net6.0 projects from referencing MoonSharp via `<ProjectReference>`.