### PR TITLE
Allow testing clr converters before executing them

### DIFF
--- a/src/MoonSharp.Interpreter/Interop/Converters/ScriptToClrConversions.cs
+++ b/src/MoonSharp.Interpreter/Interop/Converters/ScriptToClrConversions.cs
@@ -37,7 +37,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 		/// </summary>
 		internal static object DynValueToObject(DynValue value)
 		{
-			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value.Type, typeof(System.Object));
+			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value, typeof(System.Object));
 			if (converter != null)
 			{
 				var v = converter(value);
@@ -106,7 +106,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 			if (desiredType.IsByRef)
 				desiredType = desiredType.GetElementType();
 
-			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value.Type, desiredType);
+			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value, desiredType);
 			if (converter != null)
 			{
 				var v = converter(value);
@@ -276,7 +276,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 			if (desiredType.IsByRef)
 				desiredType = desiredType.GetElementType();
 
-			var customConverter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value.Type, desiredType);
+			var customConverter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value, desiredType, checkConversionPredicate: true);
 			if (customConverter != null)
 				return WEIGHT_CUSTOM_CONVERTER_MATCH;
 

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/Interop/Converters/ScriptToClrConversions.cs
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/Interop/Converters/ScriptToClrConversions.cs
@@ -37,7 +37,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 		/// </summary>
 		internal static object DynValueToObject(DynValue value)
 		{
-			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value.Type, typeof(System.Object));
+			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value, typeof(System.Object));
 			if (converter != null)
 			{
 				var v = converter(value);
@@ -106,7 +106,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 			if (desiredType.IsByRef)
 				desiredType = desiredType.GetElementType();
 
-			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value.Type, desiredType);
+			var converter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value, desiredType);
 			if (converter != null)
 			{
 				var v = converter(value);
@@ -276,7 +276,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 			if (desiredType.IsByRef)
 				desiredType = desiredType.GetElementType();
 
-			var customConverter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value.Type, desiredType);
+			var customConverter = Script.GlobalOptions.CustomConverters.GetScriptToClrCustomConversion(value, desiredType, checkConversionPredicate: true);
 			if (customConverter != null)
 				return WEIGHT_CUSTOM_CONVERTER_MATCH;
 


### PR DESCRIPTION
This fixes MoonSharp choosing the incorrect overload when multiple clr type converters are available.

The old behaviour would do something like this:
Given this lua code: `Network.Write(UInt16(1))`, MoonSharp would:
 - look at all the `Write()` method overloads. All the methods that match the parameter count would be considered in the search
 - check if the type of the parameter on the C# method signature matches a converter
 - increase all of their scores equally (because each signature has a matching converter)
 - choose the overload with the highest score, but since they all have the same score, it just picks the first one that the iterator returns

With this patch, it's now possible to choose which overload should be called by testing a predicate (`canConvert`):

```cs
Script.GlobalOptions.CustomConverters.SetScriptToClrCustomConversion(
    scriptDataType: DataType.UserData,
    clrDataType: typeof(ushort),
    canConvert: luaValue => luaValue.UserData?.Object is LuaUInt16, // THIS
    converter: luaValue => luaValue.UserData.Object is LuaUInt16 v
        ? (ushort)v
        : throw new ScriptRuntimeException("use UInt16(value) to pass primitive type 'ushort' to C#"));
```
