### PR TITLE
Fix dirty stack

### DIFF
--- a/MoonSharp.Interpreter.Tests/EndToEnd/SimpleTests.cs
+++ b/MoonSharp.Interpreter.Tests/EndToEnd/SimpleTests.cs
@@ -1556,5 +1556,49 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
         	}
 
 
+		[Test]
+		public void StackIsCleanWithLocals()
+		{
+			Assert.AreEqual(DynValue.Nil, Script.RunString(@"
+				local function test()
+				   for k, v in pairs{1} do
+				       local my
+						return my
+				   end
+				end
+				return test()"
+			));
+			
+			Assert.AreEqual(DynValue.NewTuple(DynValue.Nil, DynValue.Nil), Script.RunString(@"
+				local function test()
+				   for k, v in pairs{1} do
+				       local my, de
+						return my, de
+				   end
+				end
+				return test()"
+			));
+
+			Assert.That(DynValue.NewTuple(DynValue.NewNumber(42), DynValue.Nil), Is.EqualTo(Script.RunString(@"
+				local function test()
+				   for k, v in pairs{1} do
+				       local my, de = 42
+						return my, de
+				   end
+				end
+				return test()"
+			)));
+
+			Assert.AreEqual(DynValue.NewTuple(DynValue.NewNumber(42), DynValue.Nil), Script.RunString(@"
+				local function test()
+				   for k, v in pairs{1} do
+				       local my = 42, de
+						return my, de
+				   end
+				end
+				return test()"
+			));
+		}
+
 	}
 }

--- a/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
+++ b/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
@@ -39,7 +39,7 @@ namespace MoonSharp.Interpreter.Tree.Statements
 			}
 			else
 			{
-				m_RValues = new List<Expression>();
+				m_RValues = new List<Expression>(new Expression[] { new LiteralExpression(lcontext, DynValue.Nil) });
 			}
 
 			foreach (string name in names)


### PR DESCRIPTION
The `names.Count > 0` check in the original PR is redundant (see `while (true)` loop above)

Co-Authored-By: Aberro <3986884+Aberro@users.noreply.github.com>